### PR TITLE
PHP 8+ Implicit conversion from float-string

### DIFF
--- a/Model/Jobs.php
+++ b/Model/Jobs.php
@@ -37,14 +37,9 @@ class Jobs extends \Magento\Framework\Model\AbstractModel
     public function formatTime($key)
     {
         $ms = $this->getData($key);
-        $secs = floor($ms / 1000 % 60);
-        $mins = floor($ms / (60 * 1000) % 60);
-        $hours = floor($ms / (60 * 60 * 1000) % 60);
-        $ms = floor($ms % 1000);
+        $secs = $ms / 1000;
 
-        return  ($hours ? $hours . 'h ' : '') .
-                ($mins ? $mins . 'm ' : '') .
-                $secs . '.' . sprintf('%03d', $ms) . 's';
+        return round($secs, 4) . ' s';
     }
 
     public function formatMemory($key)


### PR DESCRIPTION
Fix PHP 8.1+ Deprecated function: Implicit conversion from float-string <float> to int loses precision in

```
1 exception(s):
Exception #0 (Exception): Deprecated Functionality: Implicit conversion from float 0.101 to int loses precision in /home/www/magento/vendor/fsw2/magento2-cron-runner/Model/Jobs.php on line 40

Exception #0 (Exception): Deprecated Functionality: Implicit conversion from float 0.101 to int loses precision in /home/www/magento/vendor/fsw2/magento2-cron-runner/Model/Jobs.php on line 40
<pre>#1 Fsw\CronRunner\Model\Jobs->formatTime() called at [vendor/fsw2/magento2-cron-runner/view/adminhtml/templates/job-details.phtml:69]
#2 include() called at [vendor/magento/framework/View/TemplateEngine/Php.php:71]
```